### PR TITLE
Fix ssl and non ssl url

### DIFF
--- a/repair_settings/repair_settings.php
+++ b/repair_settings/repair_settings.php
@@ -261,7 +261,7 @@ function action_show_settings()
 	$settings['theme_default'] = 0;
 
 	$host = empty($_SERVER['HTTP_HOST']) ? $_SERVER['SERVER_NAME'] . (empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT'] == '80' ? '' : ':' . $_SERVER['SERVER_PORT']) : $_SERVER['HTTP_HOST'];
-	$url = 'http://' . $host . substr($_SERVER['PHP_SELF'], 0, strrpos($_SERVER['PHP_SELF'], '/'));
+	$url = (empty($_SERVER['HTTPS']) ? 'http://' : 'https://') . $host . substr($_SERVER['PHP_SELF'], 0, strrpos($_SERVER['PHP_SELF'], '/'));
 	$known_settings['path_url_settings']['boardurl'][2] = $url;
 	$known_settings['path_url_settings']['boarddir'][2] = dirname(__FILE__);
 


### PR DESCRIPTION
Originally, repair_settings.php shows only non-ssl url of http:// regardless of whether the site is secured or otherwise. Thuswise, this an attemp to fix ssl url so that settings in the secured url will be shown as https:// and vice versa.

Signed-off-by: ahrasis <ahrasis@gmail.com>